### PR TITLE
feat: 텍스트/이미지 업로드 API 연동 완료

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
     implementation("androidx.hilt:hilt-navigation-compose:1.1.0")       // Hilt Navigation
     implementation("com.google.android.gms:play-services-auth:21.0.0")  // Google Sign-In
     implementation("androidx.security:security-crypto:1.1.0-alpha06")   // Encrypted Shared Preferences
+    implementation("com.squareup.okhttp3:okhttp:4.9.0")                 // OkHttp
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,7 @@ dependencies {
     ksp("com.google.dagger:hilt-android-compiler:2.50")                 // Hilt Compiler
     implementation("androidx.hilt:hilt-navigation-compose:1.1.0")       // Hilt Navigation
     implementation("com.google.android.gms:play-services-auth:21.0.0")  // Google Sign-In
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")   // Encrypted Shared Preferences
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/java/com/clipboarder/clipboarder/data/remote/api/ApiService.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/data/remote/api/ApiService.kt
@@ -20,18 +20,18 @@ import retrofit2.http.Query
  * @author YoungJin Sohn
  */
 interface ApiService {
-    @POST("/login")
+    @POST("login")
     suspend fun signIn(@Body loginRequest: SignInDto.SignInRequestDto): Response<ApiResponseDto<SignInDto.SignInResponseDto>>
 
-    @POST("/text")
+    @POST("text")
     suspend fun uploadText(@Body uploadTextRequest: TextDto.UploadTextRequestDto): Response<ApiResponseDto<UploadTextResponseDto>>
 
-    @GET("/text")
-    suspend fun downloadTextList(@Query("user_id") userId: String): Response<ApiResponseDto<TextDto.DownloadTextListResponseDto>>
+    @GET("text")
+    suspend fun downloadTextList(): Response<ApiResponseDto<TextDto.DownloadTextListResponseDto>>
 
-    @POST("/image")
+    @POST("image")
     suspend fun uploadImage(@Body uploadImageRequestDto: ImageDto.UploadImageRequestDto): Response<ApiResponseDto<ImageDto.UploadImageResponseDto>>
 
-    @GET("/image")
-    suspend fun downloadImageList(@Query("user_id") userId: String): Response<ApiResponseDto<ImageDto.DownloadImageListResponseDto>>
+    @GET("image")
+    suspend fun downloadImageList(): Response<ApiResponseDto<ImageDto.DownloadImageListResponseDto>>
 }

--- a/app/src/main/java/com/clipboarder/clipboarder/data/remote/api/ApiService.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/data/remote/api/ApiService.kt
@@ -5,11 +5,13 @@ import com.clipboarder.clipboarder.data.remote.dto.ImageDto
 import com.clipboarder.clipboarder.data.remote.dto.SignInDto
 import com.clipboarder.clipboarder.data.remote.dto.TextDto
 import com.clipboarder.clipboarder.data.remote.dto.TextDto.UploadTextResponseDto
+import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.POST
-import retrofit2.http.Query
+import retrofit2.http.Part
 
 /**
  * ApiService
@@ -29,8 +31,9 @@ interface ApiService {
     @GET("text")
     suspend fun downloadTextList(): Response<ApiResponseDto<TextDto.DownloadTextListResponseDto>>
 
+    @Multipart
     @POST("image")
-    suspend fun uploadImage(@Body uploadImageRequestDto: ImageDto.UploadImageRequestDto): Response<ApiResponseDto<ImageDto.UploadImageResponseDto>>
+    suspend fun uploadImage(@Part image: MultipartBody.Part): Response<ApiResponseDto<ImageDto.UploadImageResponseDto>>
 
     @GET("image")
     suspend fun downloadImageList(): Response<ApiResponseDto<ImageDto.DownloadImageListResponseDto>>

--- a/app/src/main/java/com/clipboarder/clipboarder/data/remote/dto/ImageDto.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/data/remote/dto/ImageDto.kt
@@ -36,9 +36,6 @@ class ImageDto {
      * @author YoungJin Sohn
      */
     data class UploadImageRequestDto(
-        @SerializedName("user_id")
-        val userId: String?,
-
         @SerializedName("content")
         val content: String?
     )

--- a/app/src/main/java/com/clipboarder/clipboarder/data/remote/dto/SignInDto.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/data/remote/dto/SignInDto.kt
@@ -31,11 +31,15 @@ class SignInDto {
      * This data class provides the necessary DTO for the sign-in response.
      *
      * @property accessToken The access token of the user.
+     * @property refreshToken The refresh token of the user.
      * @since 1.0.0
      * @author YoungJin Sohn
      */
     data class SignInResponseDto(
         @SerializedName("access_token")
-        val accessToken: String?
+        val accessToken: String?,
+
+        @SerializedName("refresh_token")
+        val refreshToken: String?
     )
 }

--- a/app/src/main/java/com/clipboarder/clipboarder/data/remote/dto/TextDto.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/data/remote/dto/TextDto.kt
@@ -36,9 +36,6 @@ class TextDto {
      * @author YoungJin Sohn
      */
     data class UploadTextRequestDto(
-        @SerializedName("user_id")
-        val userId: String?,
-
         @SerializedName("content")
         val content: String?
     )

--- a/app/src/main/java/com/clipboarder/clipboarder/data/repository/ContentRepository.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/data/repository/ContentRepository.kt
@@ -2,6 +2,7 @@ package com.clipboarder.clipboarder.data.repository
 
 import com.clipboarder.clipboarder.data.remote.api.ApiService
 import com.clipboarder.clipboarder.data.remote.dto.ApiResponseDto
+import com.clipboarder.clipboarder.data.remote.dto.ImageDto
 import com.clipboarder.clipboarder.data.remote.dto.TextDto
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -21,15 +22,13 @@ class ContentRepository @Inject constructor(private val apiService: ApiService) 
      *
      * This function copies the text to the clipboarder.
      *
-     * @param userId The user ID of the text uploader.
      * @param text The content of the text.
      * @return The response of the text upload.
      */
     fun copyTextToClipboarder(
-        userId: String,
         text: String
     ): Flow<ApiResponseDto<TextDto.UploadTextResponseDto>> = flow {
-        val uploadTextRequestDto = TextDto.UploadTextRequestDto(userId, text)
+        val uploadTextRequestDto = TextDto.UploadTextRequestDto(text)
         val response = apiService.uploadText(uploadTextRequestDto)
         if (response.isSuccessful && response.body() != null) {
             emit(response.body()!!)
@@ -43,13 +42,11 @@ class ContentRepository @Inject constructor(private val apiService: ApiService) 
      *
      * This function gets the list of texts from the clipboarder.
      *
-     * @param userId The user ID of the text uploader.
      * @return The response of the text list download.
      */
     fun getTextListFromClipboarder(
-        userId: String
     ): Flow<ApiResponseDto<TextDto.DownloadTextListResponseDto>> = flow {
-        val response = apiService.downloadTextList(userId)
+        val response = apiService.downloadTextList()
         if (response.isSuccessful && response.body() != null) {
             emit(response.body()!!)
         } else {
@@ -62,16 +59,14 @@ class ContentRepository @Inject constructor(private val apiService: ApiService) 
      *
      * This function copies the image to the clipboarder.
      *
-     * @param userId The user ID of the image uploader.
      * @param image The content of the image.
      * @return The response of the image upload.
      */
     fun copyImageToClipboarder(
-        userId: String,
         image: String
-    ): Flow<ApiResponseDto<TextDto.UploadTextResponseDto>> = flow {
-        val uploadTextRequestDto = TextDto.UploadTextRequestDto(userId, image)
-        val response = apiService.uploadText(uploadTextRequestDto)
+    ): Flow<ApiResponseDto<ImageDto.UploadImageResponseDto>> = flow {
+        val uploadImageRequestDto = ImageDto.UploadImageRequestDto(image)
+        val response = apiService.uploadImage(uploadImageRequestDto)
         if (response.isSuccessful && response.body() != null) {
             emit(response.body()!!)
         } else {
@@ -84,17 +79,15 @@ class ContentRepository @Inject constructor(private val apiService: ApiService) 
      *
      * This function gets the list of images from the clipboarder.
      *
-     * @param userId The user ID of the image uploader.
      * @return The response of the image list download.
      */
-    fun getImageListFromClipboarder(
-        userId: String
-    ): Flow<ApiResponseDto<TextDto.DownloadTextListResponseDto>> = flow {
-        val response = apiService.downloadTextList(userId)
-        if (response.isSuccessful && response.body() != null) {
-            emit(response.body()!!)
-        } else {
-            throw Exception("Image List Download Failed: ${response.message()}")
+    fun getImageListFromClipboarder(): Flow<ApiResponseDto<ImageDto.DownloadImageListResponseDto>> =
+        flow {
+            val response = apiService.downloadImageList()
+            if (response.isSuccessful && response.body() != null) {
+                emit(response.body()!!)
+            } else {
+                throw Exception("Image List Download Failed: ${response.message()}")
+            }
         }
-    }
 }

--- a/app/src/main/java/com/clipboarder/clipboarder/data/repository/ContentRepository.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/data/repository/ContentRepository.kt
@@ -6,6 +6,7 @@ import com.clipboarder.clipboarder.data.remote.dto.ImageDto
 import com.clipboarder.clipboarder.data.remote.dto.TextDto
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import okhttp3.MultipartBody
 import javax.inject.Inject
 
 /**
@@ -59,14 +60,13 @@ class ContentRepository @Inject constructor(private val apiService: ApiService) 
      *
      * This function copies the image to the clipboarder.
      *
-     * @param image The content of the image.
+     * @param imageData The image data to upload.
      * @return The response of the image upload.
      */
     fun copyImageToClipboarder(
-        image: String
+        imageData: MultipartBody.Part
     ): Flow<ApiResponseDto<ImageDto.UploadImageResponseDto>> = flow {
-        val uploadImageRequestDto = ImageDto.UploadImageRequestDto(image)
-        val response = apiService.uploadImage(uploadImageRequestDto)
+        val response = apiService.uploadImage(imageData)
         if (response.isSuccessful && response.body() != null) {
             emit(response.body()!!)
         } else {

--- a/app/src/main/java/com/clipboarder/clipboarder/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/data/repository/UserRepository.kt
@@ -1,5 +1,6 @@
 package com.clipboarder.clipboarder.data.repository
 
+import android.content.SharedPreferences
 import com.clipboarder.clipboarder.data.remote.api.ApiService
 import com.clipboarder.clipboarder.data.remote.dto.ApiResponseDto
 import com.clipboarder.clipboarder.data.remote.dto.SignInDto
@@ -16,14 +17,16 @@ import javax.inject.Inject
  * @since 1.0.0
  * @author YoungJin Sohn
  */
-class UserRepository @Inject constructor(private val apiService: ApiService) {
+class UserRepository @Inject constructor(
+    private val apiService: ApiService,
+    private val sharedPreferences: SharedPreferences
+) {
     /**
      * signIn
      *
      * This function signs in the user.
      *
-     * @param email The email of the user.
-     * @param password The password of the user.
+     * @param googleIdToken The Google id token of the user.
      * @return The response of the sign in.
      */
     fun signIn(googleIdToken: String): Flow<ApiResponseDto<SignInDto.SignInResponseDto>> =
@@ -39,4 +42,53 @@ class UserRepository @Inject constructor(private val apiService: ApiService) {
             emit(ApiResponseDto(false, null as SignInDto.SignInResponseDto?))
             throw e
         }
+
+
+    /**
+     * saveLoginInfo
+     *
+     * This function saves the login information to the shared preferences.
+     *
+     * @param accessToken The access token.
+     * @param refreshToken The refresh token.
+     * @param email The email of the user.
+     */
+    fun saveLoginInfo(accessToken: String, refreshToken: String, email: String) {
+        sharedPreferences.edit().putString("accessToken", accessToken).apply()
+        sharedPreferences.edit().putString("refreshToken", refreshToken).apply()
+        sharedPreferences.edit().putString("email", email).apply()
+    }
+
+    /**
+     * getAccessToken
+     *
+     * This function gets the access token from the shared preferences.
+     *
+     * @return The access token.
+     */
+    fun getAccessToken(): String? {
+        return sharedPreferences.getString("accessToken", null)
+    }
+
+    /**
+     * getRefreshToken
+     *
+     * This function gets the refresh token from the shared preferences.
+     *
+     * @return The refresh token.
+     */
+    fun getRefreshToken(): String? {
+        return sharedPreferences.getString("refreshToken", null)
+    }
+
+    /**
+     * getEmail
+     *
+     * This function gets the email from the shared preferences.
+     *
+     * @return The email.
+     */
+    fun getEmail(): String? {
+        return sharedPreferences.getString("email", null)
+    }
 }

--- a/app/src/main/java/com/clipboarder/clipboarder/di/AppModule.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/di/AppModule.kt
@@ -1,5 +1,9 @@
 package com.clipboarder.clipboarder.di
 
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import com.clipboarder.clipboarder.BuildConfig
 import com.clipboarder.clipboarder.data.remote.api.ApiService
 import com.clipboarder.clipboarder.data.repository.ContentRepository
@@ -7,6 +11,7 @@ import com.clipboarder.clipboarder.data.repository.UserRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -27,11 +32,22 @@ import javax.inject.Singleton
 object AppModule {
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient =
+    fun provideOkHttpClient(sharedPreferences: SharedPreferences): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(3, TimeUnit.SECONDS)
             .readTimeout(3, TimeUnit.SECONDS)
             .writeTimeout(3, TimeUnit.SECONDS)
+            .addInterceptor { chain ->
+                val token = sharedPreferences.getString("accessToken", null)
+                val request = if (token != null) {
+                    chain.request().newBuilder()
+                        .addHeader("Authorization", "Bearer $token")
+                        .build()
+                } else {
+                    chain.request()
+                }
+                chain.proceed(request)
+            }
             .build()
 
     @Provides
@@ -47,11 +63,26 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideUserRepository(apiService: ApiService): UserRepository =
-        UserRepository(apiService)
+    fun provideUserRepository(apiService: ApiService, sharedPreferences: SharedPreferences): UserRepository =
+        UserRepository(apiService, sharedPreferences)
 
     @Provides
     @Singleton
     fun provideContentRepository(apiService: ApiService): ContentRepository =
         ContentRepository(apiService)
+
+    @Provides
+    @Singleton
+    fun provideEncryptedSharedPreferences(@ApplicationContext context: Context): SharedPreferences {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        return EncryptedSharedPreferences.create(
+            context,
+            "clipboarder_prefs",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
 }

--- a/app/src/main/java/com/clipboarder/clipboarder/ui/activities/ContextMenuActivity.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/ui/activities/ContextMenuActivity.kt
@@ -2,15 +2,42 @@ package com.clipboarder.clipboarder.ui.activities
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
+import android.os.Build.VERSION
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import com.clipboarder.clipboarder.data.repository.ContentRepository
+import com.clipboarder.clipboarder.data.repository.UserRepository
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
+/**
+ * ContextMenuActivity
+ *
+ * This activity is used to handle the context menu actions.
+ *
+ * @author YoungJin Sohn
+ * @since v1.0.0
+ */
 @AndroidEntryPoint
 class ContextMenuActivity : ComponentActivity() {
+    @Inject
+    lateinit var userRepository: UserRepository
+
+    @Inject
+    lateinit var contentRepository: ContentRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (userRepository.getAccessToken() == null) {
+            Toast.makeText(this, "로그인이 필요합니다", Toast.LENGTH_SHORT).show()
+            return
+        }
 
         val action = intent.action
         intent.type?.let { type ->
@@ -48,8 +75,11 @@ class ContextMenuActivity : ComponentActivity() {
     }
 
     private fun uploadImages(intent: Intent) {
-        // 모든 이미지의 경로를 하나의 텍스트로 합쳐서 Toast로 보내기
-        val imageUriList = intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
+        val imageUriList = if (VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM, Uri::class.java)
+        } else {
+            intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM)
+        }
         imageUriList?.let {
             val combinedText = imageUriList.joinToString(separator = "\n") { uri ->
                 uri.path.toString()
@@ -61,7 +91,26 @@ class ContextMenuActivity : ComponentActivity() {
     private fun uploadText(intent: Intent) {
         val selectedText = intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)
         if (selectedText != null) {
-            Toast.makeText(this, "선택한 텍스트: $selectedText", Toast.LENGTH_SHORT).show()
+            lifecycleScope.launch {
+                contentRepository.copyTextToClipboarder(selectedText.toString())
+                    .catch { e ->
+                        // Handle any errors, e.g., show a toast message
+                        Toast.makeText(
+                            this@ContextMenuActivity,
+                            "Error: ${e.message}",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                    .collect { response ->
+                        Toast.makeText(
+                            this@ContextMenuActivity,
+                            "Text uploaded successfully",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+            }
+        } else {
+            Toast.makeText(this, "선택한 텍스트가 없습니다", Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/com/clipboarder/clipboarder/ui/activities/ContextMenuActivity.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/ui/activities/ContextMenuActivity.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Build.VERSION
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.lifecycleScope
@@ -13,6 +14,9 @@ import com.clipboarder.clipboarder.data.repository.UserRepository
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import javax.inject.Inject
 
 /**
@@ -68,10 +72,54 @@ class ContextMenuActivity : ComponentActivity() {
     }
 
     private fun uploadImage(intent: Intent) {
-        val imageUri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
-        imageUri?.let {
-            Toast.makeText(this, "이미지 경로: $imageUri", Toast.LENGTH_SHORT).show()
-        } ?: Toast.makeText(this, "이미지가 없습니다", Toast.LENGTH_SHORT).show()
+        val imageUri = if (VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+        } else {
+            intent.getParcelableExtra(Intent.EXTRA_STREAM)
+        }
+
+        imageUri?.let { uri ->
+            val mimeType = contentResolver.getType(uri)
+            val fileExtension = mimeType?.substringAfter("image/") ?: ""
+            try {
+                contentResolver.openInputStream(uri)?.use { inputStream ->
+                    val bytes = inputStream.readBytes()
+                    val requestFile = bytes.toRequestBody(mimeType?.toMediaTypeOrNull())
+                    MultipartBody.Part.createFormData(
+                        "image",
+                        "uploaded_image.$fileExtension",
+                        requestFile
+                    )
+                }?.let { imageData ->
+                    lifecycleScope.launch {
+                        try {
+                            contentRepository.copyImageToClipboarder(imageData).catch { e ->
+                                Toast.makeText(
+                                    this@ContextMenuActivity,
+                                    "Error: ${e.message}",
+                                    Toast.LENGTH_LONG
+                                ).show()
+                            }.collect { response ->
+                                Toast.makeText(
+                                    this@ContextMenuActivity,
+                                    "이미지 업로드 성공",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        } catch (e: Exception) {
+                            Toast.makeText(
+                                this@ContextMenuActivity,
+                                "Error: ${e.message}",
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
+                    }
+                } ?: Toast.makeText(this, "이미지 정보를 가져오지 못했습니다!", Toast.LENGTH_SHORT).show()
+            } catch (e: Exception) {
+                Toast.makeText(this, "이미지 정보를 가져오지 못했습니다!", Toast.LENGTH_SHORT).show()
+                Log.e("[Clipboarder] Upload image error", e.message.toString())
+            }
+        } ?: Toast.makeText(this, "이미지 정보를 가져오지 못했습니다!", Toast.LENGTH_SHORT).show()
     }
 
     private fun uploadImages(intent: Intent) {
@@ -80,38 +128,44 @@ class ContextMenuActivity : ComponentActivity() {
         } else {
             intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM)
         }
+
         imageUriList?.let {
             val combinedText = imageUriList.joinToString(separator = "\n") { uri ->
                 uri.path.toString()
             }
             Toast.makeText(this, combinedText, Toast.LENGTH_LONG).show()
-        } ?: Toast.makeText(this, "이미지가 없습니다", Toast.LENGTH_SHORT).show()
+        } ?: Toast.makeText(this, "이미지 정보를 가져오지 못했습니다!", Toast.LENGTH_SHORT).show()
     }
 
     private fun uploadText(intent: Intent) {
-        val selectedText = intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)
-        if (selectedText != null) {
+        intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)?.let { selectedText ->
             lifecycleScope.launch {
                 contentRepository.copyTextToClipboarder(selectedText.toString())
                     .catch { e ->
-                        // Handle any errors, e.g., show a toast message
                         Toast.makeText(
                             this@ContextMenuActivity,
-                            "Error: ${e.message}",
+                            "텍스트 복사 실패",
                             Toast.LENGTH_LONG
                         ).show()
+                        Log.e("[Clipboarder] Upload text error", e.message.toString())
                     }
                     .collect { response ->
-                        Toast.makeText(
-                            this@ContextMenuActivity,
-                            "Text uploaded successfully",
-                            Toast.LENGTH_SHORT
-                        ).show()
+                        if (response.result!!) {
+                            Toast.makeText(
+                                this@ContextMenuActivity,
+                                "텍스트 복사 성공",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        } else {
+                            Toast.makeText(
+                                this@ContextMenuActivity,
+                                "텍스트 복사 실패",
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
                     }
             }
-        } else {
-            Toast.makeText(this, "선택한 텍스트가 없습니다", Toast.LENGTH_SHORT).show()
-        }
+        } ?: Toast.makeText(this, "텍스트 정보를 가져오지 못했습니다!", Toast.LENGTH_SHORT).show()
     }
 
     private fun uploadTexts(intent: Intent) {

--- a/app/src/main/java/com/clipboarder/clipboarder/ui/screens/login/LoginScreenViewModel.kt
+++ b/app/src/main/java/com/clipboarder/clipboarder/ui/screens/login/LoginScreenViewModel.kt
@@ -44,9 +44,12 @@ class LoginScreenViewModel @Inject constructor(private val userRepository: UserR
                 userRepository.signIn(
                     googleIdToken = account.idToken!!
                 ).collect { responseDto ->
-                    if (responseDto.result!! == true) {
-                        // userRepository.saveToken(responseDto.data?.accessToken)
-                        Log.d("LoginScreenViewModel", "Token: ${responseDto.data?.accessToken}")
+                    if (responseDto.result!!) {
+                        userRepository.saveLoginInfo(
+                            accessToken = responseDto.data?.accessToken!!,
+                            refreshToken = responseDto.data.accessToken,
+                            email = account.email!!)
+                        Log.d("LoginScreenViewModel", "Token: ${responseDto.data.accessToken}")
                         _isLoginSuccess.value = true
                     } else {
                         Log.d("LoginScreenViewModel", "Error: error while signing up")


### PR DESCRIPTION
## 🔎 작업 내용

### 이미지/텍스트 업로드 API 연동
로컬 서버에서 텍스트 및 이미지 업로드 확인 완료. 이미지의 경우 Multipart 형식으로 전송.

<br/>

### Token 관리
로그인 시 accessToken, refreshToken, 사용자 이메일을 SharedPreferences를 이용하여 저장. 각 데이터는 저장 시 암호화하여 저장

<br/>

### Retrofit Interceptor
API 통신 시 저장된 accessToken이 존재하는 경우 자동으로 Bearer Token에 포함시켜 API 요청을 보내도록 로직 구현